### PR TITLE
Oauth2 클라이언트 세팅 및 네이버 소셜로그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,20 +30,25 @@ ext {
 dependencies {
 	//Spring
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' //활성화시 spring security의 default 비번 uuid 생성안됨
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	//MSA
-	implementation 'org.springframework.cloud:spring-cloud-starter-config'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	//implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	//implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	//DB
-	//runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	//QueryDsl
 

--- a/src/main/java/org/userservice/userservice/UserApplication.java
+++ b/src/main/java/org/userservice/userservice/UserApplication.java
@@ -4,9 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-
 public class UserApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(UserApplication.class, args);
 	}

--- a/src/main/java/org/userservice/userservice/config/CorsMvcConfig.java
+++ b/src/main/java/org/userservice/userservice/config/CorsMvcConfig.java
@@ -1,0 +1,17 @@
+package org.userservice.userservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/src/main/java/org/userservice/userservice/config/SecurityConfig.java
+++ b/src/main/java/org/userservice/userservice/config/SecurityConfig.java
@@ -9,11 +9,11 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.userservice.userservice.jwt.CustomSuccessHandler;
 import org.userservice.userservice.jwt.JwtFilter;
-import org.userservice.userservice.jwt.JwtUtil;
 import org.userservice.userservice.service.OAuth2UserDetailsService;
 
 @Configuration
@@ -23,7 +23,6 @@ public class SecurityConfig {
 
     private final OAuth2UserDetailsService OAuth2UserDetailsService;
     private final CustomSuccessHandler customSuccessHandler;
-    private final JwtUtil jwtUtil;
     private final JwtFilter jwtFilter;
 
     @Bean
@@ -42,11 +41,13 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/","/health","/auth/convert").permitAll()
+                        .requestMatchers("/webjars/**","/error").permitAll()
+                       // .requestMatchers("/").hasRole("USER_ROLE_A")
                         .anyRequest().authenticated());
         //JWTFilter
         http
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterAfter(jwtFilter, OAuth2LoginAuthenticationFilter.class);
 
         //oauth2 관련 서비스
         http

--- a/src/main/java/org/userservice/userservice/config/SecurityConfig.java
+++ b/src/main/java/org/userservice/userservice/config/SecurityConfig.java
@@ -41,9 +41,8 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/","/health","/auth/convert").permitAll()
-                        .requestMatchers("/webjars/**","/error").permitAll()
-                       // .requestMatchers("/").hasRole("USER_ROLE_A")
+                        .requestMatchers("/","/health","/auth/convert", "/favicon.ico", "/webjars/**","/error").permitAll()
+                        .requestMatchers("/auth/signup").hasAnyAuthority("ROLE_USER_A") //최초 로그인일 경우 ROLE_USER_A가 할당되고 이때만 signup 접근가능
                         .anyRequest().authenticated());
         //JWTFilter
         http

--- a/src/main/java/org/userservice/userservice/config/SecurityConfig.java
+++ b/src/main/java/org/userservice/userservice/config/SecurityConfig.java
@@ -11,7 +11,8 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.userservice.userservice.error.AccessDeniedHandlerCustom;
+import org.userservice.userservice.error.AuthenticationEntryPointCustom;
 import org.userservice.userservice.jwt.CustomSuccessHandler;
 import org.userservice.userservice.jwt.JwtFilter;
 import org.userservice.userservice.service.OAuth2UserDetailsService;
@@ -24,6 +25,8 @@ public class SecurityConfig {
     private final OAuth2UserDetailsService OAuth2UserDetailsService;
     private final CustomSuccessHandler customSuccessHandler;
     private final JwtFilter jwtFilter;
+    private final AuthenticationEntryPointCustom authenticationEntryPointCustom;
+    private final AccessDeniedHandlerCustom accessDeniedHandlerCustom;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -54,6 +57,10 @@ public class SecurityConfig {
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(OAuth2UserDetailsService))
                         .successHandler(customSuccessHandler));
+        http.
+                exceptionHandling(authenticationManager-> authenticationManager
+                        .authenticationEntryPoint(authenticationEntryPointCustom) // 401 Error 처리, 인증과정에서 실패할 시 처리
+                        .accessDeniedHandler(accessDeniedHandlerCustom)); // 403 Error 처리, role, authority 권한 관련 에러
 
         return http.build();
     }

--- a/src/main/java/org/userservice/userservice/config/SecurityConfig.java
+++ b/src/main/java/org/userservice/userservice/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package org.userservice.userservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.userservice.userservice.service.CustomOAuth2UserService;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        //csrf disable (cross-site request forgery)
+        http
+                .csrf(AbstractHttpConfigurer::disable);
+
+        //From 로그인 방식 disable
+        http
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        //oauth2
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService)));
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/userservice/userservice/controller/AuthController.java
+++ b/src/main/java/org/userservice/userservice/controller/AuthController.java
@@ -11,8 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     @GetMapping("/convert-cookie-to-header")
-    public ResponseEntity<?> cookieToHeader(@CookieValue(name = "jwtToken", required = false) String jwtToken) {
+    public ResponseEntity<?> cookieToHeader(@CookieValue(name = "Authorization", required = false) String token) {
         //최초 토큰 검증절차 진행한다.
+
         return ResponseEntity.ok("ok");
     }
 }

--- a/src/main/java/org/userservice/userservice/controller/AuthController.java
+++ b/src/main/java/org/userservice/userservice/controller/AuthController.java
@@ -1,5 +1,8 @@
 package org.userservice.userservice.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,5 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-
+    @GetMapping("/convert-cookie-to-header")
+    public ResponseEntity<?> cookieToHeader(@CookieValue(name = "jwtToken", required = false) String jwtToken) {
+        //최초 토큰 검증절차 진행한다.
+        return ResponseEntity.ok("ok");
+    }
 }

--- a/src/main/java/org/userservice/userservice/controller/AuthController.java
+++ b/src/main/java/org/userservice/userservice/controller/AuthController.java
@@ -1,5 +1,8 @@
 package org.userservice.userservice.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +13,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/auth")
 public class AuthController {
 
-    @GetMapping("/convert-cookie-to-header")
-    public ResponseEntity<?> cookieToHeader(@CookieValue(name = "Authorization", required = false) String token) {
-        //최초 토큰 검증절차 진행한다.
-
-        return ResponseEntity.ok("ok");
+    @GetMapping("/convert")
+    public ResponseEntity<?> cookieToHeader(
+            @CookieValue(name = "Authorization", required = false) String token
+            ,HttpServletResponse response) {
+        // 쿠키에서 JWT 토큰을 추출
+        if (token == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authorization cookie not found");
+        }
+        // 응답 헤더에 토큰을 추가
+        response.addHeader("Authorization", "Bearer " + token);
+        return ResponseEntity.ok("Bearer " + token);
     }
 }

--- a/src/main/java/org/userservice/userservice/controller/AuthController.java
+++ b/src/main/java/org/userservice/userservice/controller/AuthController.java
@@ -1,0 +1,11 @@
+package org.userservice.userservice.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+
+}

--- a/src/main/java/org/userservice/userservice/controller/AuthController.java
+++ b/src/main/java/org/userservice/userservice/controller/AuthController.java
@@ -1,28 +1,58 @@
 package org.userservice.userservice.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.*;
+import org.userservice.userservice.dto.OAuth2UserDetails;
+import org.userservice.userservice.dto.SignupRequest;
+import org.userservice.userservice.jwt.JwtUtil;
+import org.userservice.userservice.service.UserService;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
+
+    private final JwtUtil jwtUtil;
+    private final UserService userService;
 
     @GetMapping("/convert")
     public ResponseEntity<?> cookieToHeader(
             @CookieValue(name = "Authorization", required = false) String token
-            ,HttpServletResponse response) {
+            , HttpServletResponse response) {
         // 쿠키에서 JWT 토큰을 추출
         if (token == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authorization cookie not found");
         }
+        //TODO: 쿠키에 대한 검증
+
+
+
+
         // 응답 헤더에 토큰을 추가
         response.addHeader("Authorization", "Bearer " + token);
         return ResponseEntity.ok("Bearer " + token);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(
+            @RequestBody SignupRequest signupRequest,
+            Authentication authentication) {
+
+        OAuth2UserDetails oAuth2UserDetails = (OAuth2UserDetails) authentication.getPrincipal();
+        String providerName = oAuth2UserDetails.getProviderName();
+        userService.updateUserRole(providerName, "ROLE_USER_B");
+        String newJwt = jwtUtil.createToken(providerName, "ROLE_USER_B");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + newJwt);
+
+        return ResponseEntity.ok().headers(headers).body("Signup completed and new JWT issued");
     }
 }

--- a/src/main/java/org/userservice/userservice/domain/User.java
+++ b/src/main/java/org/userservice/userservice/domain/User.java
@@ -15,11 +15,8 @@ import lombok.NoArgsConstructor;
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "provider_name")
-    private String providerName; //oAuth2 provider + providerId
+    @Column(name = "user_id")
+    private String userId;  //oAuth2 provider + providerId
 
     @Column(name = "user_name")
     private String name;

--- a/src/main/java/org/userservice/userservice/domain/User.java
+++ b/src/main/java/org/userservice/userservice/domain/User.java
@@ -1,0 +1,35 @@
+package org.userservice.userservice.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "provider_name")
+    private String providerName; //oAuth2 provider + providerId
+
+    @Column(name = "user_name")
+    private String name;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "role")
+    private String role;
+}

--- a/src/main/java/org/userservice/userservice/dto/CustomOAuth2User.java
+++ b/src/main/java/org/userservice/userservice/dto/CustomOAuth2User.java
@@ -1,0 +1,41 @@
+package org.userservice.userservice.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final UserDto userDto;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority() {
+            @Override
+            public String getAuthority() {
+                return userDto.getRole();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+        return userDto.getName();
+    }
+
+    public String getProviderName() {
+        return userDto.getProviderName();
+    }
+}

--- a/src/main/java/org/userservice/userservice/dto/NaverResponse.java
+++ b/src/main/java/org/userservice/userservice/dto/NaverResponse.java
@@ -1,0 +1,32 @@
+package org.userservice.userservice.dto;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/org/userservice/userservice/dto/OAuth2Response.java
+++ b/src/main/java/org/userservice/userservice/dto/OAuth2Response.java
@@ -1,0 +1,13 @@
+package org.userservice.userservice.dto;
+
+public interface OAuth2Response {
+
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름)
+    String getName();
+}

--- a/src/main/java/org/userservice/userservice/dto/OAuth2UserDetails.java
+++ b/src/main/java/org/userservice/userservice/dto/OAuth2UserDetails.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 import java.util.Map;
 
 @RequiredArgsConstructor
-public class CustomOAuth2User implements OAuth2User {
+public class OAuth2UserDetails implements OAuth2User {
 
     private final UserDto userDto;
 

--- a/src/main/java/org/userservice/userservice/dto/SecurityExceptionDto.java
+++ b/src/main/java/org/userservice/userservice/dto/SecurityExceptionDto.java
@@ -1,0 +1,15 @@
+package org.userservice.userservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SecurityExceptionDto {
+
+    private String message;
+    private int statusCode;
+
+}

--- a/src/main/java/org/userservice/userservice/dto/SignupRequest.java
+++ b/src/main/java/org/userservice/userservice/dto/SignupRequest.java
@@ -1,0 +1,12 @@
+package org.userservice.userservice.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SignupRequest {
+
+    private String nickname;
+}

--- a/src/main/java/org/userservice/userservice/dto/UserDto.java
+++ b/src/main/java/org/userservice/userservice/dto/UserDto.java
@@ -7,7 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserDto {
-    private String name;
     private String providerName;
+    private String name;
     private String role;
 }

--- a/src/main/java/org/userservice/userservice/dto/UserDto.java
+++ b/src/main/java/org/userservice/userservice/dto/UserDto.java
@@ -1,0 +1,13 @@
+package org.userservice.userservice.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDto {
+    private String name;
+    private String providerName;
+    private String role;
+}

--- a/src/main/java/org/userservice/userservice/error/AccessDeniedHandlerCustom.java
+++ b/src/main/java/org/userservice/userservice/error/AccessDeniedHandlerCustom.java
@@ -1,0 +1,37 @@
+package org.userservice.userservice.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.userservice.userservice.dto.SecurityExceptionDto;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AccessDeniedHandlerCustom implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+    private static final SecurityExceptionDto exceptionDto
+            = new SecurityExceptionDto("권한이 없는 사용자 요청, 권한이 다른 상태라서 접근이 불가능합니다.", HttpStatus.FORBIDDEN.value());
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        String json = objectMapper.writeValueAsString(exceptionDto);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/org/userservice/userservice/error/AuthenticationEntryPointCustom.java
+++ b/src/main/java/org/userservice/userservice/error/AuthenticationEntryPointCustom.java
@@ -1,0 +1,38 @@
+package org.userservice.userservice.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.userservice.userservice.dto.SecurityExceptionDto;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationEntryPointCustom implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+    private static final SecurityExceptionDto exceptionDto =
+            new SecurityExceptionDto("인증되지 않은 사용자 요청, 로그인이 필요합니다.", HttpStatus.UNAUTHORIZED.value());
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authenticationException) throws IOException {
+
+        String json = objectMapper.writeValueAsString(exceptionDto);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
+++ b/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -24,6 +25,7 @@ import java.util.Iterator;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtUtil jwtUtil;
@@ -41,8 +43,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //JWT 생성
         String token = jwtUtil.createToken(providerName, role);
+        log.info("===================SOCIAL LOGIN SUCCESS====================");
         response.addCookie(createCookie("Authorization", token));
-        response.sendRedirect("http://localhost:8080/auth/convert");
+        response.sendRedirect("http://172.16.211.57:8080/auth/convert");
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
+++ b/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
@@ -42,7 +42,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         //JWT 생성
         String token = jwtUtil.createToken(providerName, role);
         response.addCookie(createCookie("Authorization", token));
-        response.sendRedirect("http://localhost:3000/");
+        response.sendRedirect("http://localhost:8080/auth/convert");
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
+++ b/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
@@ -1,0 +1,60 @@
+package org.userservice.userservice.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.userservice.userservice.dto.OAuth2UserDetails;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * 클래스 요약:
+ * OAuth2 인증 성공시 JWT 발급하는 핸들러
+ *
+ * 설명:
+ * customSuccessHandler 에서는 SecurityContext 에 저장된 인증 객체를 가져와 추가 작업(JWT 생성)을 수행가능
+ * 여기서는 SecurityContext 에서 직접 가져오는 것이 아니라, onAuthenticationSuccess 메서드의 매개변수로 전달된 Authentication 객체에서 바로 가져옴
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+
+        //OAuth2User (인증정보)
+        OAuth2UserDetails oAuth2UserDetails = (OAuth2UserDetails) authentication.getPrincipal();
+        String providerName = oAuth2UserDetails.getProviderName();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        //JWT 생성
+        String token = jwtUtil.createToken(providerName, role);
+
+        response.addCookie(createCookie("Authorization", token));
+        response.sendRedirect("http://localhost:3000/");
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
+++ b/src/main/java/org/userservice/userservice/jwt/CustomSuccessHandler.java
@@ -30,7 +30,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-
         //OAuth2User (인증정보)
         OAuth2UserDetails oAuth2UserDetails = (OAuth2UserDetails) authentication.getPrincipal();
         String providerName = oAuth2UserDetails.getProviderName();
@@ -42,19 +41,16 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //JWT 생성
         String token = jwtUtil.createToken(providerName, role);
-
         response.addCookie(createCookie("Authorization", token));
         response.sendRedirect("http://localhost:3000/");
     }
 
     private Cookie createCookie(String key, String value) {
-
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(60*60*60);
         //cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-
         return cookie;
     }
 }

--- a/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -20,17 +21,15 @@ import org.userservice.userservice.dto.SecurityExceptionDto;
 import org.userservice.userservice.dto.UserDto;
 
 import java.io.IOException;
-
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        //TODO: 최초 토큰은 pass 시켜서 cookie->header 서비스에서 처리. shouldNotFilter 메서드 사용
-        //shouldNotFilter();
         //1. 토큰 추출
         String accessToken = jwtUtil.resolveTokenHeader(request);
 

--- a/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
@@ -29,10 +29,10 @@ public class JwtFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
-        //cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음 //TODO: 최초 쿠키, 이후에는 헤더로 받을 경우는 어떤식으로 분기처리해야하나
+        //TODO: 최초 토큰은 pass 시켜서 cookie->header 서비스에서 처리. shouldNotFilter 메서드 사용
+        //shouldNotFilter();
         //1. 토큰 추출
-        String accessToken = jwtUtil.resolveTokenCookie(request);
+        String accessToken = jwtUtil.resolveTokenHeader(request);
 
         //2. 토큰 검증
         if (accessToken != null) {
@@ -65,7 +65,7 @@ public class JwtFilter extends OncePerRequestFilter {
         try {
             // ObjectMapper를 사용하여 SecurityExceptionDto 객체를 json 문자열로 변환
             ObjectMapper objectMapper = new ObjectMapper();
-            String json = objectMapper.writeValueAsString(new SecurityExceptionDto(message,statusCode)); //TODO: 필터 추가
+            String json = objectMapper.writeValueAsString(new SecurityExceptionDto(message, statusCode)); //TODO: 필터 추가
             response.getWriter().write(json); //json 문자열을 응답으로 작성
         } catch (IOException e) {
             throw new RuntimeException("Error while processing JSON", e);

--- a/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtFilter.java
@@ -1,0 +1,74 @@
+package org.userservice.userservice.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.userservice.userservice.dto.OAuth2UserDetails;
+import org.userservice.userservice.dto.SecurityExceptionDto;
+import org.userservice.userservice.dto.UserDto;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        //cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음 //TODO: 최초 쿠키, 이후에는 헤더로 받을 경우는 어떤식으로 분기처리해야하나
+        //1. 토큰 추출
+        String accessToken = jwtUtil.resolveTokenCookie(request);
+
+        //2. 토큰 검증
+        if (accessToken != null) {
+            if (!jwtUtil.validateToken(accessToken)) {
+                jwtExceptionHandler(response, "AccessToken이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED.value());
+                return;
+            }
+            //3. 검증 성공시 인증 객체 생성
+            Claims claims = jwtUtil.getUserInfoFromToken(accessToken);
+            String providerName = claims.getSubject();
+            String role = claims.get("role", String.class);
+
+            OAuth2UserDetails oAuth2UserDetails = new OAuth2UserDetails(
+                    UserDto.builder()
+                            .providerName(providerName)
+                            .role(role)
+                            .build());
+
+            Authentication authToken = new UsernamePasswordAuthenticationToken(oAuth2UserDetails, null, oAuth2UserDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    public void jwtExceptionHandler(HttpServletResponse response, String message, int statusCode) {
+        response.setStatus(statusCode);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        try {
+            // ObjectMapper를 사용하여 SecurityExceptionDto 객체를 json 문자열로 변환
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(new SecurityExceptionDto(message,statusCode)); //TODO: 필터 추가
+            response.getWriter().write(json); //json 문자열을 응답으로 작성
+        } catch (IOException e) {
+            throw new RuntimeException("Error while processing JSON", e);
+        }
+    }
+}

--- a/src/main/java/org/userservice/userservice/jwt/JwtToken.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtToken.java
@@ -1,0 +1,15 @@
+package org.userservice.userservice.jwt;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@RequiredArgsConstructor
+public class JwtToken {
+
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/org/userservice/userservice/jwt/JwtToken.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtToken.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
 @RequiredArgsConstructor
 public class JwtToken {
-
     private final String accessToken;
     private final String refreshToken;
 }

--- a/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
@@ -48,8 +48,8 @@ public class JwtUtil {
     //Authentication: JWT 생성
     public String createToken(String providerName, String role) {
         return Jwts.builder()
-                .subject(providerName)
-                .claim("role", role)
+                .subject(providerName) //AuthenticationException(AuthenticationEntryPoint 에서 검사)-> 확실하지 않음
+                .claim("role", role) //AccessDeniedException (AccessDeniedHandler 에서 검사)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
                 .signWith(secretKey)

--- a/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
@@ -1,0 +1,114 @@
+package org.userservice.userservice.jwt;
+
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * 클래스:
+ * JWT 인증 및 인가 작업을 위한 메서드 모음
+ * <p>
+ * 설명:
+ * Authentication: 소셜 로그인 성공시 SuccessHandler 에서 JWT 를 생성해 프론트로 전달
+ * Authorization: permit 이 필요한 엔드포인트에 대해 JWT 검증하여 성공시 인증 객체 및 세션 생성
+ * <p>
+ * secret: JWT 생성을 위한 비밀키 생성에 사용되는 베이스 문자열
+ * secretKey:
+ * secret 문자열을 이용해 HS256 알고리즘에 맞게 생성된 객체로 JWT 를 해당알고리즘에 맞게 암호화하여 생성
+ * HS256(HMAC-SHA256, 해시알고리즘)
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L; //액세스토큰 유효시간: 24 시간
+
+    @Value("${spring.jwt.secret}")
+    private String secret;
+    private SecretKey secretKey;
+
+
+    @PostConstruct
+    public void init() {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    //Authentication: JWT 생성
+    public String createToken(String providerName, String role) {
+        //TODO: 쿠키 값에는 blank 삽입 불가
+        return BEARER_PREFIX + Jwts.builder()
+                .subject(providerName)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    //Authorization: JWT 검증
+    public String resolveTokenHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String resolveTokenCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("Authorization")) {
+                String bearerToken = cookie.getValue();
+                if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+                    return bearerToken.substring(7);
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts
+                    .parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+
+        } catch (SignatureException e) {
+            log.error("Invalid JWT signature, signature 가 유효하지 않은 토큰 입니다.");
+        } catch (MalformedJwtException | UnsupportedJwtException e) {
+            log.error("Invalid JWT token, 유효하지 않은 jwt 토큰 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token. 만료된 jwt 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts
+                .parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
+++ b/src/main/java/org/userservice/userservice/jwt/JwtUtil.java
@@ -34,14 +34,11 @@ import java.util.Date;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtUtil {
-
-    private static final String BEARER_PREFIX = "Bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24L; //액세스토큰 유효시간: 24 시간
 
     @Value("${spring.jwt.secret}")
     private String secret;
     private SecretKey secretKey;
-
 
     @PostConstruct
     public void init() {
@@ -50,8 +47,7 @@ public class JwtUtil {
 
     //Authentication: JWT 생성
     public String createToken(String providerName, String role) {
-        //TODO: 쿠키 값에는 blank 삽입 불가
-        return BEARER_PREFIX + Jwts.builder()
+        return Jwts.builder()
                 .subject(providerName)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
@@ -63,20 +59,18 @@ public class JwtUtil {
     //Authorization: JWT 검증
     public String resolveTokenHeader(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
         return null;
     }
 
+    //TODO: cookie->header 서비스나 컨트롤러 단에서 엄격하게 검증할때 사용한다. "Bearer "를 추가하여 프론트로 전달한다.
     public String resolveTokenCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals("Authorization")) {
-                String bearerToken = cookie.getValue();
-                if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-                    return bearerToken.substring(7);
-                }
+                return cookie.getValue();
             }
         }
         return null;

--- a/src/main/java/org/userservice/userservice/repository/UserRepository.java
+++ b/src/main/java/org/userservice/userservice/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package org.userservice.userservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.userservice.userservice.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByProviderName(String providerName);
+}

--- a/src/main/java/org/userservice/userservice/repository/UserRepository.java
+++ b/src/main/java/org/userservice/userservice/repository/UserRepository.java
@@ -3,7 +3,6 @@ package org.userservice.userservice.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.userservice.userservice.domain.User;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, String> {
 
-    User findByProviderName(String providerName);
 }

--- a/src/main/java/org/userservice/userservice/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/userservice/userservice/service/CustomOAuth2UserService.java
@@ -1,0 +1,71 @@
+package org.userservice.userservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.userservice.userservice.domain.User;
+import org.userservice.userservice.dto.CustomOAuth2User;
+import org.userservice.userservice.dto.NaverResponse;
+import org.userservice.userservice.dto.OAuth2Response;
+import org.userservice.userservice.dto.UserDto;
+import org.userservice.userservice.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+
+        if (registrationId.equals("naver")) {
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        }
+        else if (registrationId.equals("google")) {
+            //oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else {
+            return null;
+        }
+
+        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬
+        String providerName = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        User user = userRepository.findByProviderName(providerName);
+
+        if (user == null) {
+            userRepository.save(User.builder()
+                    .name(oAuth2Response.getName())
+                    .providerName(providerName)
+                    .email(oAuth2Response.getEmail())
+                    .role("ROLE_USER")
+                    .build());
+
+            UserDto userDto = UserDto.builder()
+                    .name(oAuth2Response.getName())
+                    .providerName(providerName)
+                    .role("ROLE_USER")
+                    .build();
+            return new CustomOAuth2User(userDto);
+        } else {
+            userRepository.save(user.toBuilder()
+                    .name(oAuth2Response.getName())
+                    .email(oAuth2Response.getEmail())
+                    .build());
+
+            UserDto userDto = UserDto.builder()
+                    .name(oAuth2Response.getName())
+                    .providerName(user.getProviderName())
+                    .role(user.getRole())
+                    .build();
+            return new CustomOAuth2User(userDto);
+        }
+    }
+}

--- a/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
+++ b/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
@@ -49,11 +49,11 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
         //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬, ex) naver_12345
         String providerName = oAuth2Response.getProvider() + "_" + oAuth2Response.getProviderId();
         String role = "ROLE_USER_A"; //소셜로그인만 진행하였을 경우 모두 회원가입해야한다.
-        User user = userRepository.findByProviderName(providerName);
+        User user = userRepository.findById(providerName).orElse(null);
 
         if (user == null) {
             userRepository.save(User.builder()
-                    .providerName(providerName)
+                    .userId(providerName)
                     .name(oAuth2Response.getName())
                     .email(oAuth2Response.getEmail())
                     .role(role)
@@ -72,7 +72,7 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
                     .build());
 
             UserDto userDto = UserDto.builder()
-                    .providerName(user.getProviderName())
+                    .providerName(user.getUserId())
                     .name(oAuth2Response.getName())
                     .role(user.getRole())
                     .build();

--- a/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
+++ b/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
@@ -62,7 +62,7 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
             UserDto userDto = UserDto.builder()
                     .providerName(providerName)
                     .name(oAuth2Response.getName())
-                    .role(role)
+                    .role(role) //ROLE_USER_A
                     .build();
             return new OAuth2UserDetails(userDto);
         } else {
@@ -74,7 +74,7 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
             UserDto userDto = UserDto.builder()
                     .providerName(user.getUserId())
                     .name(oAuth2Response.getName())
-                    .role(user.getRole())
+                    .role(user.getRole()) //ROLE_USER_B
                     .build();
             return new OAuth2UserDetails(userDto);
         }

--- a/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
+++ b/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
@@ -46,22 +46,23 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
             return null;
         }
 
-        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬, ex) naver 12345
+        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬, ex) naver_12345
         String providerName = oAuth2Response.getProvider() + "_" + oAuth2Response.getProviderId();
+        String role = "ROLE_USER_A"; //소셜로그인만 진행하였을 경우 모두 회원가입해야한다.
         User user = userRepository.findByProviderName(providerName);
 
         if (user == null) {
             userRepository.save(User.builder()
-                    .name(oAuth2Response.getName())
                     .providerName(providerName)
+                    .name(oAuth2Response.getName())
                     .email(oAuth2Response.getEmail())
-                    .role("ROLE_USER")
+                    .role(role)
                     .build());
 
             UserDto userDto = UserDto.builder()
-                    .name(oAuth2Response.getName())
                     .providerName(providerName)
-                    .role("ROLE_USER")
+                    .name(oAuth2Response.getName())
+                    .role(role)
                     .build();
             return new OAuth2UserDetails(userDto);
         } else {
@@ -71,8 +72,8 @@ public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
                     .build());
 
             UserDto userDto = UserDto.builder()
-                    .name(oAuth2Response.getName())
                     .providerName(user.getProviderName())
+                    .name(oAuth2Response.getName())
                     .role(user.getRole())
                     .build();
             return new OAuth2UserDetails(userDto);

--- a/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
+++ b/src/main/java/org/userservice/userservice/service/OAuth2UserDetailsService.java
@@ -1,43 +1,53 @@
 package org.userservice.userservice.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.userservice.userservice.domain.User;
-import org.userservice.userservice.dto.CustomOAuth2User;
+import org.userservice.userservice.dto.OAuth2UserDetails;
 import org.userservice.userservice.dto.NaverResponse;
 import org.userservice.userservice.dto.OAuth2Response;
 import org.userservice.userservice.dto.UserDto;
 import org.userservice.userservice.repository.UserRepository;
 
+/**
+ * 클래스 요약:
+ * OAuth2 리소스 서버에서 받은 사용자 정보(OAuth2UserRequest)를 바탕으로, 사용자 정보를 로드하고 가공하는 단계
+ * <p>
+ * 설명:
+ * 인증이 완료되면 return 되는 OAuth2UserDetails 객체는 OAuth2UserDetails 객체는 Authentication 객체로 래핑되어 인증완료
+ * Authentication 객체는 SecurityContextHolder(인증 객체를 저장하는 컨테이너) 에 저장
+ * 이 후 customSuccessHandler 에서는 SecurityContext 에 저장된 인증 객체를 가져와 추가 작업(JWT 생성)을 수행가능
+ */
 @Service
 @RequiredArgsConstructor
-public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+@Slf4j
+public class OAuth2UserDetailsService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        System.out.println(oAuth2User);
+        log.info("리소스 서버로부터 인증된 유저는? = {}", oAuth2User);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        OAuth2Response oAuth2Response = null;
 
+        OAuth2Response oAuth2Response = null;
         if (registrationId.equals("naver")) {
             oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
-        }
-        else if (registrationId.equals("google")) {
+        } else if (registrationId.equals("google")) {
             //oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
-        }
-        else {
+        } else {
             return null;
         }
 
-        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬
-        String providerName = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬, ex) naver 12345
+        String providerName = oAuth2Response.getProvider() + "_" + oAuth2Response.getProviderId();
         User user = userRepository.findByProviderName(providerName);
 
         if (user == null) {
@@ -53,7 +63,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .providerName(providerName)
                     .role("ROLE_USER")
                     .build();
-            return new CustomOAuth2User(userDto);
+            return new OAuth2UserDetails(userDto);
         } else {
             userRepository.save(user.toBuilder()
                     .name(oAuth2Response.getName())
@@ -65,7 +75,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .providerName(user.getProviderName())
                     .role(user.getRole())
                     .build();
-            return new CustomOAuth2User(userDto);
+            return new OAuth2UserDetails(userDto);
         }
     }
 }

--- a/src/main/java/org/userservice/userservice/service/UserService.java
+++ b/src/main/java/org/userservice/userservice/service/UserService.java
@@ -1,0 +1,22 @@
+package org.userservice.userservice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.userservice.userservice.domain.User;
+import org.userservice.userservice.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    public void updateUserRole(String providerName, String role) {
+        User user = userRepository.findById(providerName)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with provider: " + providerName));
+
+        userRepository.save(user.toBuilder()
+                .role(role)
+                .build());
+
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -3,5 +3,30 @@ spring.config.activate.on-profile=local
 spring.application.name=userservice
 spring.cloud.config.enabled=false
 
+#db
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3308/coding_text?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=0000
 
+#DB schema log
+logging.level.org.springframework.jdbc=debug
+logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.org.hibernate.SQL=DEBUG
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.hibernate.ddl-auto=update
+
+#registration
+spring.security.oauth2.client.registration.naver.client-name=naver
+spring.security.oauth2.client.registration.naver.client-id=krmZDLHVyMcEHA1ygEHw
+spring.security.oauth2.client.registration.naver.client-secret=gfFU_BWndR
+spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.naver.scope=name,email
+
+#provider
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response
 

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -32,3 +32,6 @@ spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
 #jwt
 spring.jwt.secret=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
+
+#log
+logging.level.org.springframework.security=TRACE

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -30,3 +30,5 @@ spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oau
 spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
 spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
+#jwt
+spring.jwt.secret=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -14,7 +14,7 @@ logging.level.org.springframework.jdbc=debug
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 logging.level.org.hibernate.SQL=DEBUG
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 
 #registration
 spring.security.oauth2.client.registration.naver.client-name=naver

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,13 +1,13 @@
-spring.config.activate.on-profile=local
+spring.config.activate.on-profile=prod
 spring.application.name=userservice
 
 spring.cloud.config.enabled=false
 
 #db
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3308/coding_text?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://172.16.211.57:3308/coding_text?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 spring.datasource.username=root
-spring.datasource.password=0000
+spring.datasource.password=1234
 
 #DB schema log
 logging.level.org.springframework.jdbc=debug
@@ -20,7 +20,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.security.oauth2.client.registration.naver.client-name=naver
 spring.security.oauth2.client.registration.naver.client-id=krmZDLHVyMcEHA1ygEHw
 spring.security.oauth2.client.registration.naver.client-secret=gfFU_BWndR
-spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.redirect-uri=http://172.16.211.57:8080/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.scope=name,email
 
@@ -32,6 +32,3 @@ spring.security.oauth2.client.provider.naver.user-name-attribute=response
 
 #jwt
 spring.jwt.secret=vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
-
-#log
-logging.level.org.springframework.security=TRACE

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -5,7 +5,7 @@ spring.cloud.config.enabled=false
 
 #db
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://172.16.211.57:3308/coding_text?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://localhost:3306/coding_text?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 spring.datasource.username=root
 spring.datasource.password=1234
 
@@ -18,8 +18,8 @@ spring.jpa.hibernate.ddl-auto=update
 
 #registration
 spring.security.oauth2.client.registration.naver.client-name=naver
-spring.security.oauth2.client.registration.naver.client-id=krmZDLHVyMcEHA1ygEHw
-spring.security.oauth2.client.registration.naver.client-secret=gfFU_BWndR
+spring.security.oauth2.client.registration.naver.client-id=ha0pAZaCCgngvPYzEYsK
+spring.security.oauth2.client.registration.naver.client-secret=AVsMpp1P09
 spring.security.oauth2.client.registration.naver.redirect-uri=http://172.16.211.57:8080/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.scope=name,email


### PR DESCRIPTION
## #️연관된 티켓 넘버
CT-23

## 작업 내용
1. 네이버에 대한 소셜로그인 세팅
2. JWT 생성 및 검증 과정

## 스크린샷
![CT_oauth2_senario](https://github.com/user-attachments/assets/12024b02-3018-4555-8487-e02d4ae77fc9)


## 리뷰 요구사항


## 체크리스트
위에 사진과 같이 기본 소셜로그인 플로우는 다음과 같습니다.
소셜로그인 경우 code와 accesstoken을 발급받기 위해 네이버와 같은 소셜계정에 접근하는 과정이 필요한다. 이러한 접근책임에 대해 백엔드와 프론트엔드를 분리하기도 하지만 공식레퍼런스에서는 한 곳에서 모든 책임을 갖는 것이 권장됩니다.
따라서 이번에는 백엔드에서 해당 작업을 모두 수행하는 것으로 작업하였습니다.

## Reference (Wiki)