### PR TITLE
공지사항 목록 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' //활성화시 spring security의 default 비번 uuid 생성안됨
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	//k8s
 	//implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-all'
@@ -45,6 +44,7 @@ dependencies {
 
 	//MSA
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	//Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/org/userservice/userservice/config/SwaggerConfig.java
+++ b/src/main/java/org/userservice/userservice/config/SwaggerConfig.java
@@ -22,11 +22,8 @@ import java.util.Collections;
 @Configuration
 public class SwaggerConfig {
 
-    @Value("${swagger.server.baseUrl}")
-    private String swaggerServerBaseUrl;
-
     @Bean
-    public OpenAPI jwtApi(){
+    public OpenAPI jwtApi() {
         SecurityScheme securityScheme = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
@@ -38,7 +35,6 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
-                .security(Collections.singletonList(securityRequirement))
-                .addServersItem(new io.swagger.v3.oas.models.servers.Server().url(swaggerServerBaseUrl));
+                .security(Collections.singletonList(securityRequirement));
     }
 }

--- a/src/main/java/org/userservice/userservice/controller/UserApi.java
+++ b/src/main/java/org/userservice/userservice/controller/UserApi.java
@@ -9,9 +9,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.multipart.MultipartFile;
+import org.userservice.userservice.dto.adminclient.AnnounceResponse;
 import org.userservice.userservice.dto.user.UserInfoForBlogResponse;
 import org.userservice.userservice.dto.user.UserInfoRequest;
 import org.userservice.userservice.dto.user.UserInfoResponse;
@@ -158,4 +160,16 @@ public interface UserApi {
             })
     ResponseEntity<?> findUserInfoForBlogService(@RequestHeader("UserId") String userId);
 
+
+    @Operation(summary = "일반 사용자 공지사항 목록 조회",
+            description = "일반 사용자가 공지사항 목록을 조회할 경우 관리자 서비스에 feign client 요청을 통해 페이징 된 목록을 가져온다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "공지사항목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = UserInfoForBlogResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "공지사항을 조회하지 못했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    ResponseEntity<?> getAnnouncementsFromAdminService(int page, int size);
 }

--- a/src/main/java/org/userservice/userservice/controller/UserApi.java
+++ b/src/main/java/org/userservice/userservice/controller/UserApi.java
@@ -163,13 +163,16 @@ public interface UserApi {
 
     @Operation(summary = "일반 사용자 공지사항 목록 조회",
             description = "일반 사용자가 공지사항 목록을 조회할 경우 관리자 서비스에 feign client 요청을 통해 페이징 된 목록을 가져온다.",
+            parameters = {
+                    @Parameter(name = "page", description = "조회할 페이지 번호 (기본값: 0)", schema = @Schema(type = "integer")),
+                    @Parameter(name = "size", description = "페이지 당 데이터 개수 (기본값: 10)", schema = @Schema(type = "integer"))
+            },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "공지사항목록 조회 성공",
-                            content = @Content(schema = @Schema(implementation = UserInfoForBlogResponse.class))),
+                    @ApiResponse(responseCode = "200", description = "공지사항목록 조회 성공"),
                     @ApiResponse(responseCode = "404", description = "공지사항을 조회하지 못했습니다.",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "500", description = "서버 오류",
-                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
             })
     ResponseEntity<?> getAnnouncementsFromAdminService(int page, int size);
 }

--- a/src/main/java/org/userservice/userservice/controller/UserController.java
+++ b/src/main/java/org/userservice/userservice/controller/UserController.java
@@ -2,16 +2,17 @@ package org.userservice.userservice.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.userservice.userservice.dto.adminclient.AnnounceResponse;
 import org.userservice.userservice.dto.user.UserInfoRequest;
 import org.userservice.userservice.dto.user.UserInfoResponse;
 import org.userservice.userservice.dto.user.UserStatisticResponse;
 import org.userservice.userservice.service.UserService;
-import org.userservice.userservice.utils.SecurityUtils;
 
 @Slf4j
 @RestController
@@ -45,9 +46,17 @@ public class UserController implements UserApi {
         return ResponseEntity.ok(response);
     }
 
-    //blog-service 와 통신
+    //blog-service -> user-service
     @GetMapping("/info")
     public ResponseEntity<?> findUserInfoForBlogService(@RequestHeader("UserId") String userId) {
         return ResponseEntity.ok(userService.findUserInfoForBlogService(userId));
+    }
+
+    //user-service -> admin-service
+    @GetMapping("/announce")
+    public ResponseEntity<Page<AnnounceResponse>> getAnnouncementsFromAdminService(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(userService.getAnnouncementsFromAdminService(page,size));
     }
 }

--- a/src/main/java/org/userservice/userservice/controller/feignclient/AdminServiceClient.java
+++ b/src/main/java/org/userservice/userservice/controller/feignclient/AdminServiceClient.java
@@ -1,0 +1,16 @@
+package org.userservice.userservice.controller.feignclient;
+
+import org.springframework.cloud.openfeign.FeignClient;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.userservice.userservice.dto.adminclient.AnnounceResponse;
+
+@FeignClient(name = "admin-service")
+public interface AdminServiceClient {
+
+    @GetMapping("/admins/announce")
+    ResponseEntity<Page<AnnounceResponse>> getAnnouncements(@RequestParam("page") int page, @RequestParam("size") int size);
+}

--- a/src/main/java/org/userservice/userservice/dto/adminclient/AnnounceResponse.java
+++ b/src/main/java/org/userservice/userservice/dto/adminclient/AnnounceResponse.java
@@ -1,0 +1,21 @@
+package org.userservice.userservice.dto.adminclient;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnnounceResponse {
+    @Schema(description = "공지사항 ID", example = "1")
+    private long announceId;
+
+    @Schema(description = "공지사항 제목", example = "2024년 첫 번째 공지")
+    private String title;
+
+    @Schema(description = "공지사항 생성 날짜", example = "2024-01-01")
+    private LocalDate createdDate;
+}

--- a/src/main/java/org/userservice/userservice/error/ErrorCode.java
+++ b/src/main/java/org/userservice/userservice/error/ErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorCode {
 
-    // common
+    //common
     INTERNAL_SERVER_ERROR(500, "C001", "서버 오류"),
     INVALID_INPUT_VALUE(400, "C002", "잘못된 일력 값을 입력하였습니다."),
     INVALID_TYPE_VALUE(400, "C003", "잘못된 타입을 입력하였습니다."),
@@ -19,8 +19,11 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(500, "C006", "파일 업로드에 실패했습니다."),
     CREATION_FAILED(500, "C007", "생성에 실패하였습니다"),
 
-    // user
-    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다.");
+    //user
+    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다."),
+
+    //feignclient
+    ANNOUNCEMENT_NOT_FOUNT(404, "F001", "공지사항 정보 찾을 수 없습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/org/userservice/userservice/service/UserService.java
+++ b/src/main/java/org/userservice/userservice/service/UserService.java
@@ -24,11 +24,12 @@ import org.userservice.userservice.repository.UserRepository;
 public class UserService {
     private final UserRepository userRepository;
     private final FileUploadService fileUploadService;
-    private AdminServiceClient adminServiceClient;
+    private final AdminServiceClient adminServiceClient;
 
-    public UserService(UserRepository userRepository, @Qualifier("minio") FileUploadService fileUploadService) {
+    public UserService(UserRepository userRepository, @Qualifier("minio") FileUploadService fileUploadService, AdminServiceClient adminServiceClient) {
         this.userRepository = userRepository;
         this.fileUploadService = fileUploadService;
+        this.adminServiceClient = adminServiceClient;
     }
 
     public AuthRole signup(SignupRequest signupRequest, String userId) {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -24,21 +24,21 @@ spring.jpa.hibernate.ddl-auto=update
 spring.security.oauth2.client.registration.naver.client-name=naver
 spring.security.oauth2.client.registration.naver.client-id=${NAVER_ID}
 spring.security.oauth2.client.registration.naver.client-secret=${NAVER_SECRET}
-spring.security.oauth2.client.registration.naver.redirect-uri=http://172.16.211.57:8081/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.redirect-uri=http://172.16.211.57:19091/user-service/login/oauth2/code/naver
 spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.naver.scope=name,email,profile_image,gender,birthday,birthyear,mobile
 #Google-registration
 spring.security.oauth2.client.registration.google.client-name=google
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_SECRET}
-spring.security.oauth2.client.registration.google.redirect-uri=http://172.16.211.57:8081/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.redirect-uri=http://172.16.211.57:19091/user-service/login/oauth2/code/google
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.google.scope=profile,email
 #Kakao-registration
 spring.security.oauth2.client.registration.kakao.client-name=kakao
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_SECRET}
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://172.16.211.57:8081/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://172.16.211.57:19091/user-service/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
 spring.security.oauth2.client.registration.kakao.scope=profile_image,account_email,name, gender, birthday, birthyear, phone_number
@@ -70,9 +70,6 @@ minio.url=http://172.16.211.113:9000
 minio.access-key=minioadmin
 minio.secret-key=minioadmin
 minio.bucketName = profileimage
-
-#swagger
-swagger.server.baseUrl=http://172.16.211.57:8081
 
 #log
 logging.level.org.springframework.security=TRACE

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,11 +1,11 @@
 spring.config.activate.on-profile=local
-spring.application.name=user-service-local
+spring.application.name=user-service
 server.port=8080
 
 #eureka(
-eureka.client.register-with-eureka=false
-eureka.client.fetch-registry=false
-#eureka.client.service-url.defaultZone=http://localhost:19090/eureka
+eureka.client.register-with-eureka=true
+eureka.client.fetch-registry=true
+eureka.client.service-url.defaultZone=http://localhost:19090/eureka
 
 #db
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -71,9 +71,6 @@ minio.url=http://172.16.211.113:9000
 minio.access-key=minioadmin
 minio.secret-key=minioadmin
 minio.bucketName = profileimage
-
-#swagger
-swagger.server.baseUrl=http://localhost:8080
 
 #log
 logging.level.org.springframework.security=TRACE

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -68,9 +68,6 @@ minio.access-key=minioadmin
 minio.secret-key=minioadmin
 minio.bucketName = profileimage
 
-#swagger
-swagger.server.baseUrl=http://user-service:8081
-
 #log
 logging.level.org.springframework.security=TRACE
 


### PR DESCRIPTION
## #️연관된 티켓 넘버
> CT-13

## 작업 내용
일반 유저가 공지사항 목록을 조회 시 admin service에 feign client 요청을 통해 응답받은 결과를 전달한다.

## 스크린샷

## 리뷰 요구사항

## 체크리스트

        public Page<AnnounceResponse> getAnnouncementsFromAdminService(int page, int size) {
        ResponseEntity<Page<AnnounceResponse>> response = adminServiceClient.getAnnouncements(page, size);

        // 상태 코드가 200 OK인 경우
        if (response.getStatusCode().is2xxSuccessful()) {
            return response.getBody();  // 성공 시 Page<AnnounceResponse> 반환
        } else {
            //관리자 서비스로부터 어떤 에러가 전달되어도 하나의 에러로 전달한다.
            throw new BusinessException("공지사항을 조회하지 못했습니다.", ErrorCode.ANNOUNCEMENT_NOT_FOUNT);
        }
    }


다른 서비스에서 발생한 에러가 user service로 전달된다면 애초에 response에서 잡히지 않을 것 같은데 이 부분을 확인해봐야할 것 같습니다.

## Reference (Wiki)